### PR TITLE
Add dnqr (DuitNow QR) payment method support

### DIFF
--- a/includes/class-chip-travel-tour-api.php
+++ b/includes/class-chip-travel-tour-api.php
@@ -9,6 +9,17 @@
  */
 class Chip_Travel_Tour_API {
 	/**
+	 * DuitNow QR payment method group.
+	 *
+	 * dnqr is the modern identifier; duitnow_qr is the legacy identifier kept
+	 * for backward compatibility. The group is resolved against the merchant's
+	 * actual /payment_methods/ response at runtime, prioritizing dnqr.
+	 *
+	 * @since 1.1.0
+	 */
+	const DUITNOW_GROUP = array( 'duitnow_qr', 'dnqr' );
+
+	/**
 	 * CHIP Secret Key.
 	 *
 	 * @var $secret_key
@@ -107,6 +118,68 @@ class Chip_Travel_Tour_API {
 			'GET',
 			"/payment_methods/?brand_id={$this->brand_id}&currency={$currency}&language={$language}&amount={$amount}"
 		);
+	}
+
+	/**
+	 * Resolve the configured payment_method_whitelist against the merchant's
+	 * actual /payment_methods/ response, with dnqr-priority for the DuitNow QR group.
+	 *
+	 * Steps:
+	 *   1. Group expansion: any dnqr-group member in the whitelist expands to the full group.
+	 *   2. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
+	 *   3. Try cache. On miss, call /payment_methods/.
+	 *   4. Fallback: return expanded whitelist unchanged if the API fails.
+	 *   5. Intersect with available methods.
+	 *   6. Priority: dnqr wins when both are present.
+	 *   7. Build the final whitelist (original non-group entries + resolved group).
+	 *
+	 * @param array  $whitelist Configured payment_method_whitelist.
+	 * @param string $currency  Order currency code (e.g. 'MYR').
+	 * @param int    $amount    Order total in sen (e.g. 12345 = RM 123.45).
+	 * @return array            Final whitelist to send to CHIP.
+	 */
+	public function resolve_duitnow_methods( $whitelist, $currency, $amount ) {
+		$whitelist = array_values( (array) $whitelist );
+
+		// 1. Group expansion.
+		$has_group_member = count( array_intersect( $whitelist, self::DUITNOW_GROUP ) ) > 0;
+
+		// Short-circuit: a whitelist that does not intersect the dnqr group
+		// is returned untouched (no API call, no group injection).
+		if ( ! $has_group_member ) {
+			return $whitelist;
+		}
+
+		$expanded = array_values( array_unique( array_merge( $whitelist, self::DUITNOW_GROUP ) ) );
+
+		// 2. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
+		$cache_key = 'chip_pm_' . md5( $this->brand_id . '|' . $currency . '|' . intval( $amount / 100 ) );
+
+		// 3. Try cache. If hit, use it. If miss, call /payment_methods/.
+		$available = get_transient( $cache_key );
+		if ( false === $available ) {
+			$response = $this->payment_methods( $currency, '', $amount ); // No language param.
+			if ( ! is_array( $response ) || ! isset( $response['available_payment_methods'] ) ) {
+				// 4. Fallback: return expanded whitelist unchanged.
+				return $expanded;
+			}
+			$available = $response['available_payment_methods'];
+			set_transient( $cache_key, $available, 30 * MINUTE_IN_SECONDS );
+		}
+
+		// 5. Intersect: keep only group members the merchant actually has.
+		$resolved_group = array_values( array_intersect( self::DUITNOW_GROUP, (array) $available ) );
+
+		// 6. Priority: dnqr wins when both are present.
+		if ( in_array( 'dnqr', $resolved_group, true ) ) {
+			$resolved_group = array_values( array_diff( $resolved_group, array( 'duitnow_qr' ) ) );
+		}
+
+		// 7. Build final whitelist: original entries (with group members stripped) + resolved group.
+		$final = array_values( array_diff( $expanded, self::DUITNOW_GROUP ) );
+		$final = array_merge( $final, $resolved_group );
+
+		return $final;
 	}
 
 	public function payment_recurring_methods( $currency, $language, $amount ) {

--- a/includes/class-chip-travel-tour-api.php
+++ b/includes/class-chip-travel-tour-api.php
@@ -20,6 +20,17 @@ class Chip_Travel_Tour_API {
 	const DUITNOW_GROUP = array( 'duitnow_qr', 'dnqr' );
 
 	/**
+	 * Shopee Pay payment method group.
+	 *
+	 * shopee_pay is the modern identifier (whitelist-only); razer_shopeepay is
+	 * the legacy identifier. The group is resolved against the merchant's actual
+	 * /payment_methods/ response at runtime, prioritizing shopee_pay.
+	 *
+	 * @since 1.1.0
+	 */
+	const SHOPEE_GROUP = array( 'razer_shopeepay', 'shopee_pay' );
+
+	/**
 	 * CHIP Secret Key.
 	 *
 	 * @var $secret_key
@@ -122,16 +133,19 @@ class Chip_Travel_Tour_API {
 
 	/**
 	 * Resolve the configured payment_method_whitelist against the merchant's
-	 * actual /payment_methods/ response, with dnqr-priority for the DuitNow QR group.
+	 * actual /payment_methods/ response, applying group preference for both the
+	 * DuitNow QR (dnqr) and Shopee Pay (shopee_pay) groups.
 	 *
 	 * Steps:
-	 *   1. Group expansion: any dnqr-group member in the whitelist expands to the full group.
-	 *   2. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
-	 *   3. Try cache. On miss, call /payment_methods/.
-	 *   4. Fallback: return expanded whitelist unchanged if the API fails.
-	 *   5. Intersect with available methods.
-	 *   6. Priority: dnqr wins when both are present.
-	 *   7. Build the final whitelist (original non-group entries + resolved group).
+	 *   1. Short-circuit: if the whitelist intersects neither group, return unchanged
+	 *      (no API call, no group injection).
+	 *   2. Group expansion: any member of a configured group expands to its full group.
+	 *   3. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
+	 *   4. Try cache. On miss, call /payment_methods/ once and cache the result.
+	 *   5. Fallback: return the expanded whitelist unchanged if the API fails.
+	 *   6. Resolve each group against the available methods with preference:
+	 *      dnqr beats duitnow_qr; shopee_pay beats razer_shopeepay.
+	 *   7. Build the final whitelist (original non-group entries + resolved groups).
 	 *
 	 * @param array  $whitelist Configured payment_method_whitelist.
 	 * @param string $currency  Order currency code (e.g. 'MYR').
@@ -141,45 +155,86 @@ class Chip_Travel_Tour_API {
 	public function resolve_duitnow_methods( $whitelist, $currency, $amount ) {
 		$whitelist = array_values( (array) $whitelist );
 
-		// 1. Group expansion.
-		$has_group_member = count( array_intersect( $whitelist, self::DUITNOW_GROUP ) ) > 0;
+		$groups = array(
+			'dnqr'     => array(
+				'members'  => self::DUITNOW_GROUP,
+				'prefer'   => 'dnqr',
+				'fallback' => 'duitnow_qr',
+			),
+			'shopee'   => array(
+				'members'  => self::SHOPEE_GROUP,
+				'prefer'   => 'shopee_pay',
+				'fallback' => 'razer_shopeepay',
+			),
+		);
 
-		// Short-circuit: a whitelist that does not intersect the dnqr group
-		// is returned untouched (no API call, no group injection).
+		// 1. Short-circuit: a whitelist that intersects neither group is returned
+		// untouched (no API call, no group injection).
+		$all_members = array();
+		foreach ( $groups as $group ) {
+			$all_members = array_merge( $all_members, $group['members'] );
+		}
+
+		$has_group_member = count( array_intersect( $whitelist, $all_members ) ) > 0;
+
 		if ( ! $has_group_member ) {
 			return $whitelist;
 		}
 
-		$expanded = array_values( array_unique( array_merge( $whitelist, self::DUITNOW_GROUP ) ) );
+		// 2. Group expansion: any configured group member expands to its full group.
+		$expanded = array_values( array_unique( array_merge( $whitelist, $all_members ) ) );
 
-		// 2. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
+		// 3. Cache key: brand + currency + amount-bucket (round to 100-sen steps).
 		$cache_key = 'chip_pm_' . md5( $this->brand_id . '|' . $currency . '|' . intval( $amount / 100 ) );
 
-		// 3. Try cache. If hit, use it. If miss, call /payment_methods/.
+		// 4. Try cache. If hit, use it. If miss, call /payment_methods/ once.
 		$available = get_transient( $cache_key );
 		if ( false === $available ) {
 			$response = $this->payment_methods( $currency, '', $amount ); // No language param.
 			if ( ! is_array( $response ) || ! isset( $response['available_payment_methods'] ) ) {
-				// 4. Fallback: return expanded whitelist unchanged.
+				// 5. Fallback: return expanded whitelist unchanged.
 				return $expanded;
 			}
 			$available = $response['available_payment_methods'];
 			set_transient( $cache_key, $available, 30 * MINUTE_IN_SECONDS );
 		}
 
-		// 5. Intersect: keep only group members the merchant actually has.
-		$resolved_group = array_values( array_intersect( self::DUITNOW_GROUP, (array) $available ) );
+		$available = (array) $available;
 
-		// 6. Priority: dnqr wins when both are present.
-		if ( in_array( 'dnqr', $resolved_group, true ) ) {
-			$resolved_group = array_values( array_diff( $resolved_group, array( 'duitnow_qr' ) ) );
+		// 6. Resolve each configured group against the available methods with preference.
+		$resolved_groups = array();
+		foreach ( $groups as $group ) {
+			if ( ! $this->whitelist_has_group( $whitelist, $group['members'] ) ) {
+				continue;
+			}
+
+			// Intersect: keep only group members the merchant actually has.
+			$resolved = array_values( array_intersect( $group['members'], $available ) );
+
+			// Priority: the preferred value wins when both are present.
+			if ( in_array( $group['prefer'], $resolved, true ) ) {
+				$resolved = array_values( array_diff( $resolved, array( $group['fallback'] ) ) );
+			}
+
+			$resolved_groups = array_merge( $resolved_groups, $resolved );
 		}
 
-		// 7. Build final whitelist: original entries (with group members stripped) + resolved group.
-		$final = array_values( array_diff( $expanded, self::DUITNOW_GROUP ) );
-		$final = array_merge( $final, $resolved_group );
+		// 7. Build final whitelist: original entries (with group members stripped) + resolved groups.
+		$final = array_values( array_diff( $expanded, $all_members ) );
+		$final = array_merge( $final, $resolved_groups );
 
 		return $final;
+	}
+
+	/**
+	 * Whether the whitelist contains any member of the given group.
+	 *
+	 * @param array $whitelist Configured payment_method_whitelist.
+	 * @param array $members   Group members to look for.
+	 * @return bool
+	 */
+	private function whitelist_has_group( $whitelist, $members ) {
+		return count( array_intersect( $whitelist, $members ) ) > 0;
 	}
 
 	public function payment_recurring_methods( $currency, $language, $amount ) {

--- a/includes/tour-master-main.php
+++ b/includes/tour-master-main.php
@@ -894,7 +894,7 @@ if ( ! function_exists( 'chip_card_create_purchase' ) ) {
 // E-Wallet Payment Creation Function
 if ( ! function_exists( 'chip_ewallet_create_purchase' ) ) {
 	function chip_ewallet_create_purchase() {
-		$ret = chip_create_purchase_with_method( 'chip-ewallet', array( 'razer_grabpay', 'razer_shopeepay', 'razer_tng', 'razer_maybankqr' ) );
+		$ret = chip_create_purchase_with_method( 'chip-ewallet', array( 'razer_grabpay', 'shopee_pay', 'razer_tng', 'razer_maybankqr' ) );
 		die( wp_json_encode( $ret ) );
 	}
 }

--- a/includes/tour-master-main.php
+++ b/includes/tour-master-main.php
@@ -959,6 +959,12 @@ if ( ! function_exists( 'chip_create_purchase_with_method' ) ) {
 			} else {
 				$price = round( floatval( $price ) * 100 );
 
+				$chip = new Chip_Travel_Tour_API( $secret_key, $brand_id );
+
+				// Resolve the whitelist so the DuitNow QR group (duitnow_qr/dnqr)
+				// is sent as whatever the merchant actually has, prioritizing dnqr.
+				$payment_method_whitelist = $chip->resolve_duitnow_methods( $payment_method_whitelist, $currency_code, $price );
+
 				$send_params = array(
 					'success_callback' => add_query_arg(
 						array(
@@ -1010,7 +1016,6 @@ if ( ! function_exists( 'chip_create_purchase_with_method' ) ) {
 
 				$send_params = apply_filters( 'tourmaster_chip_payment_send_params_tour', $send_params, $tid );
 
-				$chip     = new Chip_Travel_Tour_API( $secret_key, $brand_id );
 				$purchase = $chip->create_payment( $send_params );
 
 				if ( ! array_key_exists( 'id', $purchase ) ) {

--- a/includes/tour-master-room.php
+++ b/includes/tour-master-room.php
@@ -50,7 +50,7 @@ if ( ! function_exists( 'chip_card_create_purchase_room' ) ) {
 // E-Wallet Room Payment Creation Function
 if ( ! function_exists( 'chip_ewallet_create_purchase_room' ) ) {
 	function chip_ewallet_create_purchase_room( $ret = '', $tid = '', $pay_full_amount = true ) {
-		return chip_create_purchase_room_with_method( $ret, $tid, $pay_full_amount, 'chip-ewallet', array( 'razer_grabpay', 'razer_shopeepay', 'razer_tng', 'razer_maybankqr' ) );
+		return chip_create_purchase_room_with_method( $ret, $tid, $pay_full_amount, 'chip-ewallet', array( 'razer_grabpay', 'shopee_pay', 'razer_tng', 'razer_maybankqr' ) );
 	}
 }
 

--- a/includes/tour-master-room.php
+++ b/includes/tour-master-room.php
@@ -122,6 +122,8 @@ if ( ! function_exists( 'chip_create_purchase_room_with_method' ) ) {
 
 				$price = round( floatval( $price ) * 100 );
 
+				$chip = new Chip_Travel_Tour_API( $secret_key, $brand_id );
+
 				$send_params = array(
 					'success_callback' => add_query_arg(
 						array(
@@ -162,6 +164,10 @@ if ( ! function_exists( 'chip_create_purchase_room_with_method' ) ) {
 
 				// Add payment method whitelist if specified
 				if ( ! empty( $payment_method_whitelist ) ) {
+					// Resolve the whitelist so the DuitNow QR group (duitnow_qr/dnqr)
+					// is sent as whatever the merchant actually has, prioritizing dnqr.
+					$payment_method_whitelist = $chip->resolve_duitnow_methods( $payment_method_whitelist, $currency_code, $price );
+
 					$send_params['payment_method_whitelist'] = $payment_method_whitelist;
 				}
 
@@ -177,7 +183,6 @@ if ( ! function_exists( 'chip_create_purchase_room_with_method' ) ) {
 
 				$send_params = apply_filters( 'tourmaster_chip_payment_send_params_room', $send_params, $tid );
 
-				$chip     = new Chip_Travel_Tour_API( $secret_key, $brand_id );
 				$purchase = $chip->create_payment( $send_params );
 
 				if ( ! array_key_exists( 'id', $purchase ) ) {


### PR DESCRIPTION
## Summary

Adds modern `dnqr` (DuitNow QR) support to the TourMaster plugin's `payment_method_whitelist`, mirroring chip-for-woocommerce.

- Added `Chip_Travel_Tour_API::DUITNOW_GROUP = ['duitnow_qr','dnqr']` and a shared `resolve_duitnow_methods()` resolver with a WP transient cache (brand + currency + amount-bucket). When `duitnow_qr` is configured, the whitelist is expanded in-memory and intersected with the merchant's actual `/payment_methods/` response, prioritizing `dnqr` (dropping legacy `duitnow_qr` when dnqr is available). Short-circuits (no API call) when no group member is configured; falls back to the expanded whitelist on API failure.
- Applied the resolver in both purchase flows: `tour-master-main.php` (`chip_create_purchase_with_method`, incl. the pure-DuitNow `chip_duitnow_qr_create_purchase` flow) and `tour-master-room.php` (`chip_create_purchase_room_with_method`, incl. room DuitNow flow). The fixed `array('duitnow_qr')` DuitNow-only flows now resolve to the dnqr-priority group as intended.
- Admin settings keep `duitnow_qr` as the single group entry; no separate `dnqr` option was added.